### PR TITLE
test: add test example for database mocking

### DIFF
--- a/src/health/controller.spec.ts
+++ b/src/health/controller.spec.ts
@@ -1,0 +1,83 @@
+// Test example for TDD Environments
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './controller';
+import { PrismaService } from '../prisma/prisma.service';
+import { HttpStatus } from '@nestjs/common';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+  let prismaService: PrismaService;
+
+  const mockResponse = () => {
+    const res: any = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        {
+          provide: PrismaService,
+          useValue: {
+            $queryRaw: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return status OK when database connection is successful', async () => {
+    jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([{ ok: 1 }]);
+
+    const response = mockResponse();
+    await controller.check(response);
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(response.json).toHaveBeenCalledWith({
+      status: true,
+      detail: { database: true },
+    });
+  });
+
+  it('should return status SERVICE_UNAVAILABLE when database connection fails', async () => {
+    jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([{ ok: 0 }]);
+
+    const response = mockResponse();
+    await controller.check(response);
+
+    expect(response.status).toHaveBeenCalledWith(
+      HttpStatus.SERVICE_UNAVAILABLE,
+    );
+    expect(response.json).toHaveBeenCalledWith({
+      status: false,
+      detail: { database: false },
+    });
+  });
+
+  it('should return status SERVICE_UNAVAILABLE when database connection throws error', async () => {
+    jest
+      .spyOn(prismaService, '$queryRaw')
+      .mockRejectedValue(new Error('DB Connection Error'));
+
+    const response = mockResponse();
+    await controller.check(response);
+
+    expect(response.status).toHaveBeenCalledWith(
+      HttpStatus.SERVICE_UNAVAILABLE,
+    );
+    expect(response.json).toHaveBeenCalledWith({
+      status: false,
+      detail: { database: false },
+    });
+  });
+});

--- a/src/health/controller.ts
+++ b/src/health/controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 import { Response } from 'express';
 
 @Controller('health')


### PR DESCRIPTION
1. 데이터베이스 response mock하는 방법을 포함한 테스트코드입니다. 
2. HealthCheck쪽 코드가 repository / controller 분리가 명시적으로 되어 있지 않아서 현재는 합쳐져있는 테스트이나, 대부분의 상황에서는 repository용 테스트 / controller용 테스트가 분리되는 형태가 될 것입니다. 
3. 테스트는 `pnpm run test` 로 돌려보세요.
4. 앞으로 거의 모든 상황에서, 테스트를 우선적으로 작성할 계획입니다. 초기에는 적응이 안 될 수 있지만, 더 넓은 타임 윈도우를 보았을 때 이 편이 훨씬 더 오류 상황을 덜 겪는 방향입니다. 
5. 볼륨이 너무 커질 것 같다면 시나리오에 대한 테스트 먼저 PR로 올려주세요. 
6. CI는 다음에 셋업하겠습니다. 


<img width="617" alt="스크린샷 2025-05-15 오후 6 33 42" src="https://github.com/user-attachments/assets/804c8fb0-5199-4699-858b-5ce04b172b1d" />