### PR TITLE
feat/add-image: 나무와 식당에 이미지 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,7 +118,6 @@ model Restaurant {
   latitude  Float
   longitude Float
   createdAt DateTime          @default(now())
-  images    String[]
   savedBy   SavedRestaurant[]
 }
 
@@ -131,8 +130,7 @@ model SavedRestaurant {
   restaurant          Restaurant @relation(fields: [restaurantId], references: [id])
   restaurantId        String
 
-  review              String? // 한 줄 리뷰
-  description         String?
+  review              String?
   createdAt           DateTime   @default(now())
   updatedAt           DateTime   @updatedAt
   recommendedByUsers  String[]
@@ -143,15 +141,6 @@ model SavedRestaurant {
   @@id([userId,restaurantId])
 }
 
-model SavedRestaurantImages {
-  id String @db.Uuid @id
-
-  // SavedRestaurantId
-  restaurantId String @db.Uuid
-  userId String @db.Uuid
-
-  imageUri String
-}
 
 model Follower {
   userId     String @db.Uuid 
@@ -161,12 +150,6 @@ model Follower {
 
   @@id([userId, followerId])
   @@index([followerId]) 
-}
-
-model Images {
-  key         String
-  uploadedAt  DateTime  @default(now())
-  @@id([key])
 }
 
 model SearchRestaurantTag {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,6 +118,7 @@ model Restaurant {
   latitude  Float
   longitude Float
   createdAt DateTime          @default(now())
+  images    String[]
   savedBy   SavedRestaurant[]
 }
 
@@ -137,6 +138,7 @@ model SavedRestaurant {
   recommendedByUsers  String[]
   treeType            Int
   tag                 Tag[]
+  images              String[]
 
   @@id([userId,restaurantId])
 }
@@ -159,6 +161,12 @@ model Follower {
 
   @@id([userId, followerId])
   @@index([followerId]) 
+}
+
+model Images {
+  key         String
+  uploadedAt  DateTime  @default(now())
+  @@id([key])
 }
 
 model SearchRestaurantTag {

--- a/src/auth/service.ts
+++ b/src/auth/service.ts
@@ -11,11 +11,12 @@ import * as admin from 'firebase-admin';
 import { OnboardingInfoRequest } from './dto/onboarding.dto';
 import { RegisterRequest } from './dto/register.dto';
 import { SocialLoginDto } from './dto/social-login.dto';
-import { SocialProvider, User } from '@prisma/client';
+import { FollowerStatus, SocialProvider, User } from '@prisma/client';
 import { FirebaseLoginResponseDto } from './dto/authUser.dto';
 import { sign as signJwt } from '../auth/libs/jwt';
 import { ConfigService } from '@nestjs/config';
 import * as jwt from 'jsonwebtoken';
+import { INSTRUCTION_USER } from '@/consts';
 
 @Injectable()
 export class AuthService {
@@ -28,6 +29,35 @@ export class AuthService {
   private generateJwtToken(uid: string): string {
     const secret = this.configService.get<string>('jwt.secret');
     return signJwt({ uid }, secret);
+  }
+
+  private async createUserFromFirebase(
+    firebaseUid: string,
+    email: string,
+    displayName: string | null,
+    providerType?: SocialProvider,
+  ): Promise<User> {
+    const user = await this.prismaService.user.create({
+      data: {
+        firebaseUid,
+        email,
+        username: `user_${firebaseUid.slice(0, 8)}`,
+        nickname: displayName || '',
+        isOnboarded: false,
+        socialProvider: providerType,
+      },
+    });
+
+    // force follow instruction user
+    await this.prismaService.follower.create({
+      data: {
+        userId: user.id,
+        followerId: INSTRUCTION_USER,
+        status: FollowerStatus.ACCEPTED,
+      },
+    });
+
+    return user;
   }
 
   async validateUser(decoded: FirebaseInformation) {
@@ -125,16 +155,12 @@ export class AuthService {
         const displayName = fbUser.displayName;
         if (!email)
           throw new UnauthorizedException('이메일이 없는 계정입니다.');
-        user = await this.prismaService.user.create({
-          data: {
-            firebaseUid,
-            email,
-            username: `user_${firebaseUid.slice(0, 8)}`,
-            nickname: displayName || '',
-            isOnboarded: false,
-            socialProvider: providerType,
-          },
-        });
+        user = await this.createUserFromFirebase(
+          firebaseUid,
+          email,
+          displayName,
+          providerType,
+        );
         const accessToken = this.generateJwtToken(user.id);
         return { accessToken, user };
       }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,1 @@
+export const INSTRUCTION_USER = 'deadbeef-cafe-babe-face-c0ffeecafe';

--- a/src/images/service.ts
+++ b/src/images/service.ts
@@ -1,31 +1,60 @@
 import { Injectable } from '@nestjs/common';
 import { S3Service } from './infrastructure/s3';
+import { PrismaService } from '@/prisma/prisma.service';
 
 @Injectable()
 export class ImagesService {
-  constructor(private readonly s3Service: S3Service) {}
+  constructor(
+    private readonly s3Service: S3Service,
+    private readonly prisma: PrismaService
+  ) {}
 
   async uploadSeedImage(file: Express.Multer.File) {
     const result = await this.s3Service.uploadImage(file, 'images/seed');
+    await this.prisma.images.create({ data: { key: result.key } });
     return { url: result.url };
   }
 
   async uploadUserProfileImage(file: Express.Multer.File) {
     const result = await this.s3Service.uploadImage(file, 'images/profile');
+    await this.prisma.images.create({ data: { key: result.key } });
     return { url: result.url };
   }
 
   async uploadRestaurantImage(file: Express.Multer.File) {
     const result = await this.s3Service.uploadImage(file, 'images/restaurant');
+    await this.prisma.images.create({ data: { key: result.key } });
     return { url: result.url };
   }
 
   async uploadReviewImage(file: Express.Multer.File) {
     const result = await this.s3Service.uploadImage(file, 'images/review');
+    await this.prisma.images.create({ data: { key: result.key } });
     return { url: result.url };
   }
 
   async deleteImage(key: string) {
-    return await this.s3Service.deleteImage(key);
+    await this.s3Service.deleteImage(key);
+
+    await this.prisma.$transaction([
+      this.prisma.images.delete({ where: { key } }),
+
+      this.prisma.user.updateMany({
+        where: { profileImageUrl: key },
+        data: { profileImageUrl: null }
+      }),
+
+      this.prisma.$executeRaw`
+        SELECT "Restaurant"
+        SET images = array_remove(images, ${key})
+        WHERE ${key} = ANY(images)
+      `,
+
+      this.prisma.$executeRaw`
+        SELECT "SavedRestaurant"
+        SET images = array_remove(images, ${key})
+        WHERE ${key} = ANY(images)
+      `,
+    ])
   }
 }

--- a/src/search/usecases/searchUser.spec.ts
+++ b/src/search/usecases/searchUser.spec.ts
@@ -11,6 +11,7 @@ describe('SearchUserUseCase', () => {
 
   const mockUserParam: UserParam = {
     id: 'user-1',
+    firebaseUid: 'firebase-uid-1',
     email: 'test@example.com',
     username: 'testuser',
     nickname: 'Test User',
@@ -23,6 +24,7 @@ describe('SearchUserUseCase', () => {
 
   const mockUserParam2: UserParam = {
     id: 'user-2',
+    firebaseUid: 'firebase-uid-2',
     email: 'test2@example.com',
     username: 'testuser2',
     nickname: 'Test User 2',

--- a/src/tree/controller.spec.ts
+++ b/src/tree/controller.spec.ts
@@ -25,6 +25,7 @@ const mockTreeDetailResponse: TreeDetailResponse = {
   createdAt: new Date('2025-07-16T12:00:00Z'),
   updatedAt: new Date('2025-07-16T12:00:00Z'),
   recommendationCount: 1,
+  images: []
 };
 
 describe('TreeController (unit)', () => {
@@ -117,6 +118,7 @@ describe('TreeController (unit)', () => {
         tags: [Tag.SPICY_FOOD_LOVER, Tag.LATE_NIGHT_EATER],
         review: '최고의 야식!',
         description: '역시 떡볶이는 엽떡이지',
+        images: []
       };
       const expectedResult = { treeId: `${mockUserId}_${mockRestaurantId}` };
       (service.plantTree as jest.Mock).mockResolvedValue(expectedResult);

--- a/src/tree/controller.ts
+++ b/src/tree/controller.ts
@@ -91,7 +91,7 @@ export class TreeController {
     @User() user: UserParam,
     @Res() res: Response,
   ) {
-    const result = await this.tree.getTreeById(treeId, user.);
+    const result = await this.tree.getTreeById(treeId, user);
     return res.status(HttpStatus.OK).json(result);
   }
 
@@ -113,10 +113,7 @@ export class TreeController {
     @User() user: UserParam,
     @Res() res: Response,
   ) {
-    const result = await this.tree.getTreesByRestaurantId(
-      restaurantId,
-      user.id,
-    );
+    const result = await this.tree.getTreesByRestaurantId(restaurantId, user);
     return res.status(HttpStatus.OK).json(result);
   }
 
@@ -157,7 +154,7 @@ export class TreeController {
     @User() user: UserParam,
     @Res() res: Response,
   ) {
-    const result = await this.tree.plantTree(plantTreeDto, user.id);
+    const result = await this.tree.plantTree(plantTreeDto, user);
     return res.status(HttpStatus.CREATED).json(result);
   }
 
@@ -193,7 +190,7 @@ export class TreeController {
     @User() user: UserParam,
     @Res() res: Response,
   ) {
-    const result = this.tree.getFollowersTree(user.id, restaurantId);
+    const result = this.tree.getFollowersTree(user, restaurantId);
     return res.status(HttpStatus.OK).json(result);
   }
 }

--- a/src/tree/dto.ts
+++ b/src/tree/dto.ts
@@ -67,13 +67,13 @@ export class PlantTreeDto {
   @MaxLength(50)
   review: string;
 
-  @ApiProperty({
-    description: '상세평 (300자 이내)',
-    example: '특이한 향이 입혀져있어요~',
-  })
-  @IsString()
-  @MaxLength(300)
-  description: string;
+  // @ApiProperty({
+  //   description: '상세평 (300자 이내)',
+  //   example: '특이한 향이 입혀져있어요~',
+  // })
+  // @IsString()
+  // @MaxLength(300)
+  // description: string;
 
   @IsOptional()
   @IsArray()
@@ -91,10 +91,10 @@ export class PlantTreeDto {
   @IsArray()
   @IsString({ each: true })
   @ApiProperty({
-    description: 'images 엔드포인트에서 받은 이미지 링크의 배열',
-    example: ['cloudfront-1234.com/sha256-hash.jpg',]
+    description: 'images 엔드포인트에서 받은 이미지 URL',
+    example: ['https://cloudfront-1234.com/sha256-hash.jpg'],
   })
-  images: string[]
+  images: string[];
 }
 
 export class TreeDetailResponse {
@@ -140,11 +140,11 @@ export class TreeDetailResponse {
   })
   review: string;
 
-  @ApiProperty({
-    description: '추가 설명',
-    example: '버크셔K 특로스시켜야함',
-  })
-  description: string;
+  // @ApiProperty({
+  //   description: '추가 설명',
+  //   example: '버크셔K 특로스시켜야함',
+  // })
+  // description: string;
 
   @ApiProperty({
     description: '태그 목록',
@@ -174,9 +174,9 @@ export class TreeDetailResponse {
 
   @ApiProperty({
     description: 'CloudFrontURL로 조합된 이미지 링크의 배열',
-    example: ['https://a1b2c3d4.cloudfront.net/review/sha-256-hash.jpg',]
+    example: ['https://a1b2c3d4.cloudfront.net/review/sha-256-hash.jpg'],
   })
-  images: string[]
+  images: string[];
 }
 
 export class TreeListResponse {

--- a/src/tree/dto.ts
+++ b/src/tree/dto.ts
@@ -86,6 +86,15 @@ export class PlantTreeDto {
     required: false,
   })
   tags?: Tag[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @ApiProperty({
+    description: 'images 엔드포인트에서 받은 이미지 링크의 배열',
+    example: ['cloudfront-1234.com/sha256-hash.jpg',]
+  })
+  images: string[]
 }
 
 export class TreeDetailResponse {
@@ -162,6 +171,12 @@ export class TreeDetailResponse {
     example: 0,
   })
   recommendationCount: number;
+
+  @ApiProperty({
+    description: 'CloudFrontURL로 조합된 이미지 링크의 배열',
+    example: ['https://a1b2c3d4.cloudfront.net/review/sha-256-hash.jpg',]
+  })
+  images: string[]
 }
 
 export class TreeListResponse {

--- a/src/tree/repository.ts
+++ b/src/tree/repository.ts
@@ -169,7 +169,7 @@ export class TreeRepository {
     plantTreeDto: PlantTreeDto,
     userId: string,
   ): Promise<SavedRestaurant> {
-    const { restaurantId, treeType, review, description, tags } = plantTreeDto;
+    const { restaurantId, treeType, review, description, tags, images } = plantTreeDto;
 
     return await this.prisma.savedRestaurant.create({
       data: {
@@ -179,6 +179,7 @@ export class TreeRepository {
         description,
         review,
         tag: tags,
+        images
       },
     });
   }

--- a/src/tree/repository.ts
+++ b/src/tree/repository.ts
@@ -169,17 +169,16 @@ export class TreeRepository {
     plantTreeDto: PlantTreeDto,
     userId: string,
   ): Promise<SavedRestaurant> {
-    const { restaurantId, treeType, review, description, tags, images } = plantTreeDto;
+    const { restaurantId, treeType, review, tags, images } = plantTreeDto;
 
     return await this.prisma.savedRestaurant.create({
       data: {
         userId,
         restaurantId,
         treeType,
-        description,
         review,
         tag: tags,
-        images
+        images,
       },
     });
   }

--- a/src/tree/service.spec.ts
+++ b/src/tree/service.spec.ts
@@ -36,6 +36,7 @@ const mockTreeDetail: TreeDetail = {
     recommendedByUsers: [mockUserId],
     treeType: 4, // 단풍나무 씨앗
     tag: [Tag.SPICY_FOOD_LOVER, Tag.LATE_NIGHT_EATER],
+    images: []
   },
 };
 
@@ -52,6 +53,7 @@ const mockTreeDetailResponse: TreeDetailResponse = {
   createdAt: new Date('2025-07-16T12:00:00Z'),
   updatedAt: new Date('2025-07-16T12:00:00Z'),
   recommendationCount: 1,
+  images: []
 };
 
 describe('TreeService (unit)', () => {
@@ -172,10 +174,30 @@ describe('TreeService (unit)', () => {
       await expect(service.plantTree(plantTreeDto, mockUserId)).rejects.toThrow(NotFoundException);
     });
 
-    it('이미 나무가 심겨 있으면 ConflictException을 던져야 함', async () => {
+    it('이미 나무가 심어져 있으면 ConflictException을 던져야 함', async () => {
       jest.spyOn(prisma.restaurant, 'findUnique').mockResolvedValue({} as any);
       jest.spyOn(prisma.savedRestaurant, 'findUnique').mockResolvedValue({} as any);
       await expect(service.plantTree(plantTreeDto, mockUserId)).rejects.toThrow(ConflictException);
+    });
+    
+    it('유효하지 않은 이미지가 포함된 경우 BadRequestException을 던져야 함', async () => {
+      const dtoWithInvalidImages: PlantTreeDto = {
+        ...plantTreeDto,
+        images: ['valid-key-1', 'invalid-key-2'],
+      };
+      jest.spyOn(prisma.images, 'findMany').mockResolvedValue([{ key: 'valid-key-1', uploadedAt: new Date() }]);
+      jest.spyOn(prisma.restaurant, 'findUnique').mockResolvedValue({} as any);
+      jest.spyOn(prisma.savedRestaurant, 'findUnique').mockResolvedValue(null);
+      
+      await expect(service.plantTree(dtoWithInvalidImages, mockUserId)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(prisma.images.findMany).toHaveBeenCalledWith({
+        where: {
+          key: { in: dtoWithInvalidImages.images },
+        },
+        select: { key: true },
+      });
     });
   });
 

--- a/src/tree/service.ts
+++ b/src/tree/service.ts
@@ -159,7 +159,7 @@ export class TreeService {
       throw new NotFoundException('존재하지 않는 Restaurant입니다.');
 
     const existingTree = await this.prisma.savedRestaurant.findUnique({
-      where: { userId_restaurantId: { userId, restaurantId } },
+      where: { userId_restaurantId: { userId: user.id, restaurantId } },
     });
     if (existingTree)
       throw new ConflictException('이미 나무를 심은 Restaurant입니다.');

--- a/src/tree/service.ts
+++ b/src/tree/service.ts
@@ -27,7 +27,6 @@ const toTreeDetailResponse = (detail: TreeDetail): TreeDetailResponse => {
     longitude: String(detail.restaurant.longitude),
     treeType: detail.tree.treeType,
     review: detail.tree.review,
-    description: detail.tree.description,
     tags: detail.tree.tag,
     createdAt: detail.tree.createdAt,
     updatedAt: detail.tree.updatedAt,
@@ -164,9 +163,15 @@ export class TreeService {
     if (existingTree)
       throw new ConflictException('이미 나무를 심은 Restaurant입니다.');
 
-    if (images && images.length > 0) await this.validateImages(images);
+    const savableImages = this.stripImageUrlPrefix(images);
 
-    const newTree = await this.treeRepository.plantTree(plantTreeDto, user.id);
+    const newTree = await this.treeRepository.plantTree(
+      {
+        ...plantTreeDto,
+        images: savableImages,
+      },
+      user.id,
+    );
     return {
       treeId: `${newTree.userId}_${newTree.restaurantId}`,
     };
@@ -179,21 +184,27 @@ export class TreeService {
     return recommendations.map(toTreeDetailResponse);
   }
 
-  private async validateImages(keys: string[]): Promise<void> {
-    const foundKeys = await this.prisma.images.findMany({
-      where: {
-        key: { in: keys },
-      },
-      select: { key: true },
-    });
-    if (foundKeys.length === keys.length) return;
-
-    const foundKeysSet = new Set(foundKeys.map((e) => e.key));
-    const missing = keys.filter((key) => !foundKeysSet.has(key));
-
-    throw new BadRequestException({
-      message: `key에 해당하는 이미지가 없습니다. ${missing.join(', ')}`,
-      missingImages: missing,
-    });
+  stripImageUrlPrefix(urlList: string[]): string[] {
+    return urlList.map((url) =>
+      url.replace(`https://${config().s3.cloudfrontUrl}/`, ''),
+    );
   }
+
+  // private async validateImages(keys: string[]): Promise<void> {
+  //   const foundKeys = await this.prisma.images.findMany({
+  //     where: {
+  //       key: { in: keys },
+  //     },
+  //     select: { key: true },
+  //   });
+  //   if (foundKeys.length === keys.length) return;
+
+  //   const foundKeysSet = new Set(foundKeys.map((e) => e.key));
+  //   const missing = keys.filter((key) => !foundKeysSet.has(key));
+
+  //   throw new BadRequestException({
+  //     message: `key에 해당하는 이미지가 없습니다. ${missing.join(', ')}`,
+  //     missingImages: missing,
+  //   });
+  // }
 }

--- a/src/tree/service.ts
+++ b/src/tree/service.ts
@@ -172,6 +172,7 @@ export class TreeService {
       },
       user.id,
     );
+
     return {
       treeId: `${newTree.userId}_${newTree.restaurantId}`,
     };

--- a/src/tree/service.ts
+++ b/src/tree/service.ts
@@ -10,10 +10,15 @@ import { Coordinate, PlantTreeDto, TreeDetailResponse } from './dto';
 import { PrismaService } from '@/prisma/prisma.service';
 import { TreeDetail } from './types';
 import { UserParam } from '@/user/params/user';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import config from '@/config';
 
 const toTreeDetailResponse = (detail: TreeDetail): TreeDetailResponse => {
   if (!detail.tree || !detail.restaurant) return null;
+
+  const images = (detail.tree.images ?? []).map(
+    (key) => `https://${config().s3.cloudfrontUrl}/${key}`,
+  );
+
   return {
     treeId: `${detail.tree.userId}_${detail.tree.restaurantId}`,
     name: detail.restaurant.name,
@@ -27,6 +32,7 @@ const toTreeDetailResponse = (detail: TreeDetail): TreeDetailResponse => {
     createdAt: detail.tree.createdAt,
     updatedAt: detail.tree.updatedAt,
     recommendationCount: detail.tree.recommendedByUsers.length,
+    images,
   };
 };
 
@@ -115,8 +121,11 @@ export class TreeService {
     return treeDatas.map(toTreeDetailResponse);
   }
 
-  async waterTree(treeId: string, user: UserParam): Promise<TreeDetailResponse> {
-    const lastWatered = user.lastWatered || new Date(0)
+  async waterTree(
+    treeId: string,
+    user: UserParam,
+  ): Promise<TreeDetailResponse> {
+    const lastWatered = user.lastWatered || new Date(0);
 
     if (Date.now() - lastWatered.getTime() < 4 * 60 * 60 * 1000) {
       throw new BadRequestException({
@@ -141,18 +150,26 @@ export class TreeService {
     plantTreeDto: PlantTreeDto,
     user: UserParam,
   ): Promise<{ treeId: string }> {
-    try{
-      const newTree = await this.treeRepository.plantTree(plantTreeDto, user.id);
-      return {
-        treeId: `${newTree.userId}_${newTree.restaurantId}`,
-      };
-    } catch(err) {
-      if (err instanceof PrismaClientKnownRequestError){
-        if (err.code === 'P2002') throw new ConflictException("이미 나무를 심은 식당입니다.")
-        if (err.code === 'P2003') throw new NotFoundException("해당 ID의 식당을 찾을 수 없습니다.")
-      }
-      throw err
-    }
+    const { restaurantId, images } = plantTreeDto;
+
+    const restaurant = await this.prisma.restaurant.findUnique({
+      where: { id: restaurantId },
+    });
+    if (!restaurant)
+      throw new NotFoundException('존재하지 않는 Restaurant입니다.');
+
+    const existingTree = await this.prisma.savedRestaurant.findUnique({
+      where: { userId_restaurantId: { userId, restaurantId } },
+    });
+    if (existingTree)
+      throw new ConflictException('이미 나무를 심은 Restaurant입니다.');
+
+    if (images && images.length > 0) await this.validateImages(images);
+
+    const newTree = await this.treeRepository.plantTree(plantTreeDto, user.id);
+    return {
+      treeId: `${newTree.userId}_${newTree.restaurantId}`,
+    };
   }
 
   async getRecommendations(): Promise<TreeDetailResponse[]> {
@@ -160,5 +177,23 @@ export class TreeService {
     console.log('Getting recommendations');
     const recommendations = await this.treeRepository.getRecommendations();
     return recommendations.map(toTreeDetailResponse);
+  }
+
+  private async validateImages(keys: string[]): Promise<void> {
+    const foundKeys = await this.prisma.images.findMany({
+      where: {
+        key: { in: keys },
+      },
+      select: { key: true },
+    });
+    if (foundKeys.length === keys.length) return;
+
+    const foundKeysSet = new Set(foundKeys.map((e) => e.key));
+    const missing = keys.filter((key) => !foundKeysSet.has(key));
+
+    throw new BadRequestException({
+      message: `key에 해당하는 이미지가 없습니다. ${missing.join(', ')}`,
+      missingImages: missing,
+    });
   }
 }


### PR DESCRIPTION
* 스키마에 이미지의 key와 업로드 시각을 관리하기 위한 Images 모델 새로 정의

* 나무 심기 시에 이미지를 추가할 수 있고, 해당 이미지 해시에 대한 검증 로직 추가

* ImageService에서 S3 업로드 성공 시 Images 데이터베이스에도 기록
* Delete 로직도 일단 RawQuery를 통해 간단하게 구현